### PR TITLE
Fixing drawing order so that screen overlays are drawn last.

### DIFF
--- a/src/rv/ui/screens/LiveGameScreen.java
+++ b/src/rv/ui/screens/LiveGameScreen.java
@@ -91,12 +91,14 @@ public class LiveGameScreen extends ViewerScreenBase implements ServerComm.Serve
 
     @Override
     public void render(GL2 gl, GLU glu, GLUT glut, Viewport vp) {
-        super.render(gl, glu, glut, vp);
-
         tr.beginRendering(viewer.getScreen().w, viewer.getScreen().h);
         if (viewer.getDrawings().isVisible())
+            // Render annotations before other things so that screen overlays may be later rendered
+            // on top of the annotations
             renderAnnotations();
         tr.endRendering();
+
+        super.render(gl, glu, glut, vp);
     }
 
     @Override

--- a/src/rv/ui/screens/ViewerScreenBase.java
+++ b/src/rv/ui/screens/ViewerScreenBase.java
@@ -103,13 +103,15 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
         }
         tr.endRendering();
 
-        for (Screen overlay : overlays)
-            if (overlay.isVisible())
-                overlay.render(gl, glu, glut, vp);
-
         vp.apply(gl);
         if (textOverlays.size() > 0)
             renderTextOverlays(vp.w, vp.h);
+
+        // Render screen overlays last so that they may cover text and won't have other text
+        // accidentally drawn over them
+        for (Screen overlay : overlays)
+            if (overlay.isVisible())
+                overlay.render(gl, glu, glut, vp);
     }
 
     private String formatNumTeamPlayers(Team team) {


### PR DESCRIPTION
This fixes annotations being drawn over screens and also includes fixing text overlays such as "Goal scored <team>" from being drawn over screens.  Closes https://github.com/magmaOffenburg/RoboViz/issues/48.