### PR TITLE
Always keeping game state and selection changed listeners in ViewerSc…

### DIFF
--- a/src/rv/ui/screens/ViewerScreenBase.java
+++ b/src/rv/ui/screens/ViewerScreenBase.java
@@ -80,6 +80,9 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
         Configuration.Graphics config = viewer.getConfig().graphics;
         firstPersonFOV = config.firstPersonFOV;
         thirdPersonFOV = config.thirdPersonFOV;
+
+        viewer.getWorldModel().getGameState().addListener(this);
+        viewer.getWorldModel().addSelectionChangeListener(this);
     }
 
     @Override
@@ -176,16 +179,12 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
             canvas.addMouseMotionListener(this);
             canvas.addMouseWheelListener(this);
             viewer.getUI().getCameraControl().attachToCanvas(canvas);
-            viewer.getWorldModel().getGameState().addListener(this);
-            viewer.getWorldModel().addSelectionChangeListener(this);
         } else {
             canvas.removeKeyListener(this);
             canvas.removeMouseListener(this);
             canvas.removeMouseMotionListener(this);
             canvas.removeMouseWheelListener(this);
             viewer.getUI().getCameraControl().detachFromCanvas(canvas);
-            viewer.getWorldModel().getGameState().removeListener(this);
-            viewer.getWorldModel().removeSelectionChangeListener(this);
         }
 
         for (Screen overlay : overlays)


### PR DESCRIPTION
…reenBase even if ViewerScreenBase is not enabled as updates from the listeners may still need to be processed when not enabled.  It's possible to have a goal scored requiring a text overlay notice of this while the play mode selection screen is up and ViewerScreenBase is disabled, as well as a selection change through the drawing protocol possibly requiring a robot vantage change.  Closes https://github.com/magmaOffenburg/RoboViz/issues/59.