### PR TITLE
Fixing bug where the first frame of a logfile was not being parsed an…

### DIFF
--- a/src/rv/comm/rcssserver/LogPlayer.java
+++ b/src/rv/comm/rcssserver/LogPlayer.java
@@ -382,6 +382,12 @@ public class LogPlayer {
         public void run() {
             setPlaying(true);
 
+            try {
+                // Make sure we parse and render the first frame of the log
+                parseFrame();
+            } catch (Exception e) {
+            }
+
             while (!aborted) {
                 if (logfile.isAtEndOfLog())
                     pause();


### PR DESCRIPTION
…d rendered.  This closes https://github.com/magmaOffenburg/RoboViz/issues/65.