### PR TITLE
Fixing issue where cameras weren't initalized immediately when loadin…

### DIFF
--- a/src/rv/Viewer.java
+++ b/src/rv/Viewer.java
@@ -304,6 +304,7 @@ public class Viewer extends GLProgram implements GLEventListener {
         world = new WorldModel();
         world.init(drawable.getGL(), contentManager, config, mode);
         drawings = new Drawings();
+        ui = new UserInterface(this, drawingFilter);
 
         if (mode == Mode.LIVE) {
             netManager = new NetworkManager();
@@ -315,7 +316,7 @@ public class Viewer extends GLProgram implements GLEventListener {
             else
                 logPlayer.setWorldModel(world);
         }
-        ui = new UserInterface(this, drawingFilter);
+
         ui.init();
         renderer = new Renderer(this);
         renderer.init(drawable, contentManager, glInfo);


### PR DESCRIPTION
…g logs due to UserInterface not being created yet and SimsparkController being added as a listener to GameState before a log was loaded. Closes https://github.com/magmaOffenburg/RoboViz/issues/69.