### PR TITLE
Adding the ability to log and replay draw commands in logfiles.

### DIFF
--- a/resources/help/controls.html
+++ b/resources/help/controls.html
@@ -50,6 +50,14 @@
             <td>N</td>
             <td>Toggle number of active players per team</td>
         </tr>
+        <tr>
+            <td>Y</td>
+            <td>Display drawings panel</td>
+        </tr>
+        <tr>
+            <td>T</td>
+            <td>Toggle all drawings</td>
+        </tr>
 
         <tr><td><br/></td></tr>
         <tr>
@@ -185,14 +193,6 @@
         <tr>
             <td>O</td>
             <td>Display playmode overlay</td>
-        </tr>
-        <tr>
-            <td>P</td>
-            <td>Display drawings panel</td>
-        </tr>
-        <tr>
-            <td>T</td>
-            <td>Toggle all drawings</td>
         </tr>
         <tr>
             <td>L</td>

--- a/src/rv/Viewer.java
+++ b/src/rv/Viewer.java
@@ -312,7 +312,7 @@ public class Viewer extends GLProgram implements GLEventListener {
             netManager.getServer().addChangeListener(world.getGameState());
         } else {
             if (!init)
-                logPlayer = new LogPlayer(logFile, world, config);
+                logPlayer = new LogPlayer(logFile, world, config, this);
             else
                 logPlayer.setWorldModel(world);
         }

--- a/src/rv/comm/NetworkManager.java
+++ b/src/rv/comm/NetworkManager.java
@@ -29,7 +29,7 @@ import rv.comm.rcssserver.ServerComm;
  */
 public class NetworkManager {
 
-    private DrawComm   agentComm;
+    private DrawComm   agentComm = null;
     private ServerComm serverComm;
 
     public DrawComm getAgentComm() {
@@ -47,11 +47,16 @@ public class NetworkManager {
             e.printStackTrace();
         }
         serverComm = new ServerComm(viewer.getWorldModel(), config, viewer.getMode());
+        if (agentComm != null) {
+            agentComm.addListener(serverComm);
+        }
     }
 
     public void shutdown() {
-        if (agentComm != null)
+        if (agentComm != null) {
             agentComm.shutdown();
+            agentComm.removeListener(serverComm);
+        }
         serverComm.disconnect();
     }
 }

--- a/src/rv/comm/drawing/DrawComm.java
+++ b/src/rv/comm/drawing/DrawComm.java
@@ -22,6 +22,8 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import js.io.ByteUtil;
 import rv.Viewer;
 import rv.comm.drawing.commands.Command;
@@ -71,9 +73,23 @@ public class DrawComm {
         }
     }
 
-    private final static boolean SHOW_WARNINGS = true;
-    private final Viewer         viewer;
-    private ReceiveThread        packetReceiver;
+    public interface DrawCommListener {
+        void drawCommandReceived(byte[] command);
+    }
+
+    private final List<DrawCommListener> listeners     = new ArrayList<>();
+
+    private final static boolean         SHOW_WARNINGS = true;
+    private final Viewer                 viewer;
+    private ReceiveThread                packetReceiver;
+
+    public void addListener(DrawCommListener l) {
+        listeners.add(l);
+    }
+
+    public void removeListener(DrawCommListener l) {
+        listeners.remove(l);
+    }
 
     /** Creates a new AgentComm */
     public DrawComm(Viewer viewer, int port) throws SocketException {
@@ -108,6 +124,8 @@ public class DrawComm {
                 }
                 return;
             } else {
+                for (DrawCommListener l : listeners)
+                    l.drawCommandReceived(pktData);
                 cmd.execute();
             }
         }

--- a/src/rv/comm/rcssserver/ILogfileReader.java
+++ b/src/rv/comm/rcssserver/ILogfileReader.java
@@ -5,6 +5,10 @@ import java.io.IOException;
 
 public interface ILogfileReader {
 
+    public interface LogfileListener {
+        void haveDrawCmds();
+    }
+
     /**
      * @return true if the reader represents a valid logfile
      */
@@ -51,6 +55,10 @@ public interface ILogfileReader {
      * Moves the current frame back by one frame.
      */
     void stepAnywhere(int frame) throws IOException;
+
+    void addListener(LogfileListener l);
+
+    void removeListener(LogfileListener l);
 
     File getFile();
 }

--- a/src/rv/comm/rcssserver/LogAnalyzerThread.java
+++ b/src/rv/comm/rcssserver/LogAnalyzerThread.java
@@ -3,6 +3,7 @@ package rv.comm.rcssserver;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+import rv.Viewer;
 import rv.world.Team;
 import rv.world.WorldModel;
 
@@ -43,11 +44,15 @@ public class LogAnalyzerThread extends Thread {
     private Float                lastTime       = null;
     private Float                stepSize       = null;
     private boolean              aborted        = false;
+    private final Viewer         viewer;
+    private final LogPlayer      logPlayer;
 
-    public LogAnalyzerThread(File file, ResultCallback callback) {
+    public LogAnalyzerThread(File file, ResultCallback callback, Viewer viewer, LogPlayer logPlayer) {
         super();
         this.file = file;
         this.callback = callback;
+        this.viewer = viewer;
+        this.logPlayer = logPlayer;
     }
 
     public void abort() {
@@ -61,7 +66,8 @@ public class LogAnalyzerThread extends Thread {
         logfile = null;
 
         try {
-            logfile = new LogfileReaderBuffered(new Logfile(file), 200);
+            logfile = new LogfileReaderBuffered(new Logfile(file, viewer, false), 200);
+            logfile.addListener(logPlayer);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/rv/comm/rcssserver/LogfileReaderBuffered.java
+++ b/src/rv/comm/rcssserver/LogfileReaderBuffered.java
@@ -187,4 +187,14 @@ public class LogfileReaderBuffered implements ILogfileReader {
     public File getFile() {
         return decoratee.getFile();
     }
+
+    @Override
+    public void addListener(LogfileListener l) {
+        decoratee.addListener(l);
+    }
+
+    @Override
+    public void removeListener(LogfileListener l) {
+        decoratee.removeListener(l);
+    }
 }

--- a/src/rv/ui/screens/LiveGameScreen.java
+++ b/src/rv/ui/screens/LiveGameScreen.java
@@ -27,8 +27,6 @@ import js.jogl.view.Viewport;
 import js.math.vector.Vec3f;
 import rv.Configuration;
 import rv.Viewer;
-import rv.comm.drawing.BufferedSet;
-import rv.comm.drawing.annotations.Annotation;
 import rv.comm.rcssserver.ServerComm;
 import rv.comm.rcssserver.ServerSpeedBenchmarker;
 import rv.world.ISelectable;
@@ -73,31 +71,8 @@ public class LiveGameScreen extends ViewerScreenBase implements ServerComm.Serve
         }
     }
 
-    private void renderAnnotations() {
-        List<BufferedSet<Annotation>> sets = viewer.getDrawings().getAnnotationSets();
-        if (sets.size() > 0) {
-            for (BufferedSet<Annotation> set : sets) {
-                if (set.isVisible()) {
-                    ArrayList<Annotation> annotations = set.getFrontSet();
-                    for (Annotation a : annotations) {
-                        if (a != null) {
-                            renderBillboardText(a.getText(), new Vec3f(a.getPos()), a.getColor());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     @Override
     public void render(GL2 gl, GLU glu, GLUT glut, Viewport vp) {
-        tr.beginRendering(viewer.getScreen().w, viewer.getScreen().h);
-        if (viewer.getDrawings().isVisible())
-            // Render annotations before other things so that screen overlays may be later rendered
-            // on top of the annotations
-            renderAnnotations();
-        tr.endRendering();
-
         super.render(gl, glu, glut, vp);
     }
 
@@ -118,18 +93,12 @@ public class LiveGameScreen extends ViewerScreenBase implements ServerComm.Serve
             resetTimeIfExpired();
             viewer.getNetManager().getServer().kickOff(false);
             break;
-        case KeyEvent.VK_P:
-            viewer.getUI().getShapeSetPanel().showFrame(viewer.getFrame());
-            break;
         case KeyEvent.VK_O:
             if (viewer.getWorldModel().getGameState() != null
                     && viewer.getWorldModel().getGameState().getPlayModes() != null) {
                 setEnabled((GLCanvas) viewer.getCanvas(), false);
                 playmodeOverlay.setVisible(true);
             }
-            break;
-        case KeyEvent.VK_T:
-            viewer.getDrawings().toggle();
             break;
         case KeyEvent.VK_C:
             if (!viewer.getNetManager().getServer().isConnected()) {

--- a/src/rv/ui/screens/ViewerScreenBase.java
+++ b/src/rv/ui/screens/ViewerScreenBase.java
@@ -20,7 +20,9 @@ import js.math.BoundingBox;
 import js.math.vector.Vec3f;
 import rv.Configuration;
 import rv.Viewer;
+import rv.comm.drawing.BufferedSet;
 import rv.comm.drawing.annotations.AgentAnnotation;
+import rv.comm.drawing.annotations.Annotation;
 import rv.comm.rcssserver.GameState;
 import rv.ui.view.RobotVantageBase;
 import rv.ui.view.RobotVantageFirstPerson;
@@ -85,10 +87,30 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
         viewer.getWorldModel().addSelectionChangeListener(this);
     }
 
+    private void renderAnnotations() {
+        List<BufferedSet<Annotation>> sets = viewer.getDrawings().getAnnotationSets();
+        if (sets.size() > 0) {
+            for (BufferedSet<Annotation> set : sets) {
+                if (set.isVisible()) {
+                    ArrayList<Annotation> annotations = set.getFrontSet();
+                    for (Annotation a : annotations) {
+                        if (a != null) {
+                            renderBillboardText(a.getText(), new Vec3f(a.getPos()), a.getColor());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     @Override
     public void render(GL2 gl, GLU glu, GLUT glut, Viewport vp) {
         // text overlays
         tr.beginRendering(viewer.getScreen().w, viewer.getScreen().h);
+        if (viewer.getDrawings().isVisible())
+            // Render annotations before other things so that screen overlays may be later rendered
+            // on top of the annotations
+            renderAnnotations();
         if (agentOverheadType != AgentOverheadType.NONE) {
             renderAgentOverheads(viewer.getWorldModel().getLeftTeam());
             renderAgentOverheads(viewer.getWorldModel().getRightTeam());
@@ -257,6 +279,12 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
             break;
         case KeyEvent.VK_TAB:
             cyclePlayers(e.isShiftDown() ? -1 : 1);
+            break;
+        case KeyEvent.VK_T:
+            viewer.getDrawings().toggle();
+            break;
+        case KeyEvent.VK_Y:
+            viewer.getUI().getShapeSetPanel().showFrame(viewer.getFrame());
             break;
         }
     }


### PR DESCRIPTION
For this feature I'm adding draw commands to the front of normal logfile frames as doing so allows easy synchronization and ordering between draw commands and scene updates.  This shouldn't have any affect on normal logfile playback as all that is extra that is being done is to check lines in logfiles to see if they begin with "[" as that is what draw commands begin with (a string representation of a byte array which seemed the safest way to record draw commands).

There is a nasty issue when drawing things where roboviz might lockup when updating the value of the slider in the log player controls due to swing not being thread safe.  I've protected against this by using invokeLater(), however invokeLater() seems to slow things down a bit in terms of refresh rate on my laptop.  Due to this potential slowdown invokeLater() is only used if draw commands are present in the logfile.  

Draw commands don't update very well when playing backwards but I'm not too concerned about this.  With this change I'm also always enabling rewind as rewind clears all drawings.  Additionally I've changed the mapping of the drawings panel to be the 'Y' key from the 'P' key as 'P' is already used by the log player and now drawings can be shown in both live and log modes.

This feature has been tested with the roboviz drawing examples.  Closes https://github.com/magmaOffenburg/RoboViz/issues/28.