### PR TITLE
Fixing drawing of annotations in different robot vantages.

### DIFF
--- a/src/rv/Renderer.java
+++ b/src/rv/Renderer.java
@@ -61,6 +61,10 @@ public class Renderer implements WindowResizeListener {
         this.vantage = vantage;
     }
 
+    public Camera3D getVantage() {
+        return vantage;
+    }
+
     public EffectManager getEffectManager() {
         return effectManager;
     }

--- a/src/rv/ui/screens/ViewerScreenBase.java
+++ b/src/rv/ui/screens/ViewerScreenBase.java
@@ -170,7 +170,7 @@ public abstract class ViewerScreenBase extends ScreenBase implements KeyListener
     }
 
     protected void renderBillboardText(String text, Vec3f pos3D, float[] color) {
-        Camera3D camera = viewer.getUI().getCamera();
+        Camera3D camera = viewer.getRenderer().getVantage();
         Vec3f screenPos = camera.project(pos3D, viewer.getScreen());
         int x = (int) (screenPos.x - tr.getBounds(text).getWidth() / 2);
         int y = (int) screenPos.y;


### PR DESCRIPTION
Sometimes looks a little odd in the first person perspective robot vantage but I believe that's just because of distortion.  Really simple fix that probably should have been noticed earlier.  Closes https://github.com/magmaOffenburg/RoboViz/issues/34.