### PR TITLE
Fixing bug where log player is occasionally hanging when playing back…

### DIFF
--- a/src/rv/comm/rcssserver/Logfile.java
+++ b/src/rv/comm/rcssserver/Logfile.java
@@ -53,9 +53,6 @@ public class Logfile implements ILogfileReader {
     /** if we should execute draw commands */
     private final boolean               execDrawCmds;
 
-    /** if draw commands have been found in the log */
-    private boolean                     haveDrawCmds;
-
     private final List<LogfileListener> listeners = new ArrayList<>();
 
     /**
@@ -75,7 +72,6 @@ public class Logfile implements ILogfileReader {
         this.viewer = viewer;
         this.execDrawCmds = execDrawCmds;
         numFrames = 1700;
-        haveDrawCmds = false;
         open();
     }
 
@@ -221,11 +217,8 @@ public class Logfile implements ILogfileReader {
         }
 
         while (line.startsWith("[")) {
-            if (!haveDrawCmds) {
-                haveDrawCmds = true;
-                for (LogfileListener l : listeners)
-                    l.haveDrawCmds();
-            }
+            for (LogfileListener l : listeners)
+                l.haveDrawCmds();
 
             int endIndex = line.indexOf("]");
             if (endIndex == -1) {

--- a/src/rv/ui/screens/PlayerControls.java
+++ b/src/rv/ui/screens/PlayerControls.java
@@ -239,17 +239,19 @@ class PlayerControls extends FramePanelBase implements LogPlayer.StateChangeList
 
         if (!player.logfileHasDrawCmds()) {
             slider.setValue(player.getDesiredFrame());
+            slider.setEnabled(player.isValid());
+            sliderUpdate = false;
         } else {
             // Swing is not thread safe and running draw commands with the call to set the value of
             // slider can lock things up if we don't protect against this
             SwingUtilities.invokeLater(new Runnable() {
                 public void run() {
                     slider.setValue(player.getDesiredFrame());
+                    slider.setEnabled(player.isValid());
+                    sliderUpdate = false;
                 }
             });
         }
-        slider.setEnabled(player.isValid());
-        sliderUpdate = false;
     }
 
     public void dispose() {


### PR DESCRIPTION
… logs with draw commands due to Swing not being thread safe.  Basically there was a race condition such that the variable in the log player indicating if the log contained draw commands was set and fixed to be false before draw commands were detected.  Now every time draw commands are detected a listener is called alerting the log player that there are draw commands in the log file.   Closes #78.