### PR TITLE
Fixing start script so that it will properly process the tilda charac…

### DIFF
--- a/scripts/roboviz.sh
+++ b/scripts/roboviz.sh
@@ -6,7 +6,7 @@ do
     if [[ $1 == --logFile=* ]];
     then
 	logFileName=${1#*=}
-	DIR_LOGFILE="$( cd "$( dirname "$logFileName" )" && pwd )"
+	DIR_LOGFILE="$( eval cd "$( dirname "$logFileName" )" && pwd )"
 	LOGFILE=$DIR_LOGFILE/$(basename $logFileName)
 	args="$args --logFile=$LOGFILE"
     else


### PR DESCRIPTION
…ter in command line arguments.  Using the eval command for this fix, which can be dangerous from a security standpoint, however user input is contained as an argument to the dirname command so I doubt anything too evil could be executed.  Also I'm not exactly worried about security issues with roboviz.  Closes #80.