### PR TITLE
Fixing issue where incorrect host was shown in window title when over…

### DIFF
--- a/src/rv/Viewer.java
+++ b/src/rv/Viewer.java
@@ -450,7 +450,7 @@ public class Viewer extends GLProgram
         if (mode != Mode.LIVE)
             return;
 
-        String host = server.isConnected() ? config.networking.serverHost : null;
+        String host = server.isConnected() ? config.networking.getServerHost() : null;
         frame.setTitle(formatTitle(host));
     }
 


### PR DESCRIPTION
…ridding the host with the serverHost command line argument.  Closes #83.