### PR TITLE
Changing the scale of the ball tracker camera such that it increases …

### DIFF
--- a/src/rv/ui/UserInterface.java
+++ b/src/rv/ui/UserInterface.java
@@ -108,7 +108,7 @@ public class UserInterface implements KeyListener {
             setActiveScreen(new LogfileModeScreen(viewer));
 
         ballTracker = new TargetTrackerCamera(viewer.getWorldModel().getBall(), camera,
-                viewer.getWorldModel().getGameState());
+                viewer.getWorldModel().getGameState(), viewer.getScreen());
     }
 
     private FPCamera initCamera(GLCapabilitiesImmutable glcaps) {

--- a/src/rv/ui/UserInterface.java
+++ b/src/rv/ui/UserInterface.java
@@ -108,7 +108,7 @@ public class UserInterface implements KeyListener {
             setActiveScreen(new LogfileModeScreen(viewer));
 
         ballTracker = new TargetTrackerCamera(viewer.getWorldModel().getBall(), camera,
-                viewer.getWorldModel().getGameState(), viewer.getScreen());
+                viewer.getWorldModel().getGameState());
     }
 
     private FPCamera initCamera(GLCapabilitiesImmutable glcaps) {
@@ -136,7 +136,7 @@ public class UserInterface implements KeyListener {
         cameraControl.update(elapsedMS);
         camera.update(elapsedMS);
 
-        ballTracker.update();
+        ballTracker.update(viewer.getScreen());
     }
 
     public void render(GL2 gl, GLU glu, GLUT glut) {

--- a/src/rv/ui/view/TargetTrackerCamera.java
+++ b/src/rv/ui/view/TargetTrackerCamera.java
@@ -50,27 +50,19 @@ public class TargetTrackerCamera {
     public void update(Viewport screen) {
         if (!enabled || target.getPosition() == null)
             return;
+
         float scale = (float) (1 - (0.02f * playbackSpeed));
+        scale = scaleWithBallSpeed(screen, scale);
+
         Vec3f cameraTarget = offsetTargetPosition(target.getPosition());
 
-        // Percentage of screen near edges where the scale is increased when
-        // target is within this threshold percentage of the screen's edge
-        float SCREEN_THRESH_PERC = 0.1f;
+        camera.setPosition(Vec3f.lerp(cameraTarget, camera.getPosition(), scale));
+        camera.setRotation(new Vec2f(-30, 180));
+    }
 
-        // Factor to increase scale by
-        float SCALE_FACTOR = 2.0f;
-
+    private float scaleWithBallSpeed(Viewport screen, float scale) {
         // Get position of target relative to screen
         Vec3f screenPos = camera.project(target.getPosition(), screen);
-
-        if (screenPos.x < screen.w * SCREEN_THRESH_PERC
-                || screenPos.x > screen.w * (1 - SCREEN_THRESH_PERC)
-                || screenPos.y < screen.h * SCREEN_THRESH_PERC
-                || screenPos.y > screen.h * (1 - SCREEN_THRESH_PERC)) {
-            // Outside of SCREEN_THRESH_PERC boundaries so increase scale by
-            // SCALE_FACTOR
-            // scale = (float) (1 - (0.02f * playbackSpeed * SCALE_FACTOR));
-        }
 
         if (lastScreenPos == null) {
             lastScreenPos = screenPos;
@@ -79,7 +71,7 @@ public class TargetTrackerCamera {
         // Maximum factor that velocity can increase scale by
         float VEL_SCALE_FACTOR_MAX = 3.0f;
 
-        // Amount that screen velocity is multiplied by when determing scale
+        // Amount that screen velocity is multiplied by when determining scale
         float VEL_SCALE_FACTOR = 0.003f;
 
         double screenVel = Math.sqrt(Math.pow((double) (lastScreenPos.x - screenPos.x), 2.0)
@@ -88,10 +80,7 @@ public class TargetTrackerCamera {
                 1 - (0.02f * playbackSpeed * VEL_SCALE_FACTOR_MAX));
         lastScreenPos = screenPos;
 
-        camera.setPosition(Vec3f.lerp(cameraTarget, camera.getPosition(), scale));
-
-        camera.setRotation(new Vec2f(-30, 180));
-
+        return scale;
     }
 
     /**

--- a/src/rv/ui/view/TargetTrackerCamera.java
+++ b/src/rv/ui/view/TargetTrackerCamera.java
@@ -30,6 +30,7 @@ public class TargetTrackerCamera {
     private GameState      gs;
     private ISelectable    target;
     private double         playbackSpeed = 1;
+    private Vec3f          lastScreenPos;
 
     public void toggleEnabled() {
         enabled = !enabled;
@@ -43,6 +44,7 @@ public class TargetTrackerCamera {
         this.target = target;
         this.camera = camera;
         this.gs = gs;
+        lastScreenPos = null;
     }
 
     public void update(Viewport screen) {
@@ -67,8 +69,24 @@ public class TargetTrackerCamera {
                 || screenPos.y > screen.h * (1 - SCREEN_THRESH_PERC)) {
             // Outside of SCREEN_THRESH_PERC boundaries so increase scale by
             // SCALE_FACTOR
-            scale = (float) (1 - (0.02f * playbackSpeed * SCALE_FACTOR));
+            // scale = (float) (1 - (0.02f * playbackSpeed * SCALE_FACTOR));
         }
+
+        if (lastScreenPos == null) {
+            lastScreenPos = screenPos;
+        }
+
+        // Maximum factor that velocity can increase scale by
+        float VEL_SCALE_FACTOR_MAX = 3.0f;
+
+        // Amount that screen velocity is multiplied by when determing scale
+        float VEL_SCALE_FACTOR = 0.003f;
+
+        double screenVel = Math.sqrt(Math.pow((double) (lastScreenPos.x - screenPos.x), 2.0)
+                + Math.pow((double) (lastScreenPos.y - screenPos.y), 2.0));
+        scale = (float) Math.max(Math.min(1 - screenVel * VEL_SCALE_FACTOR, scale),
+                1 - (0.02f * playbackSpeed * VEL_SCALE_FACTOR_MAX));
+        lastScreenPos = screenPos;
 
         camera.setPosition(Vec3f.lerp(cameraTarget, camera.getPosition(), scale));
 

--- a/src/rv/ui/view/TargetTrackerCamera.java
+++ b/src/rv/ui/view/TargetTrackerCamera.java
@@ -53,7 +53,7 @@ public class TargetTrackerCamera {
 
         // Percentage of screen near edges where the scale is increased when
         // target is within this threshold percentage of the screen's edge
-        float SCREEN_THRESH_PERC = 0.05f;
+        float SCREEN_THRESH_PERC = 0.1f;
 
         // Factor to increase scale by
         float SCALE_FACTOR = 2.0f;

--- a/src/rv/ui/view/TargetTrackerCamera.java
+++ b/src/rv/ui/view/TargetTrackerCamera.java
@@ -28,7 +28,6 @@ public class TargetTrackerCamera {
     private boolean        enabled       = false;
     private final FPCamera camera;
     private GameState      gs;
-    private Viewport       screen;
     private ISelectable    target;
     private double         playbackSpeed = 1;
 
@@ -40,23 +39,21 @@ public class TargetTrackerCamera {
         this.playbackSpeed = playbackSpeed;
     }
 
-    public TargetTrackerCamera(ISelectable target, FPCamera camera, GameState gs, Viewport screen) {
+    public TargetTrackerCamera(ISelectable target, FPCamera camera, GameState gs) {
         this.target = target;
         this.camera = camera;
         this.gs = gs;
-        this.screen = screen;
     }
 
-    public void update() {
+    public void update(Viewport screen) {
         if (!enabled || target.getPosition() == null)
             return;
-
         float scale = (float) (1 - (0.02f * playbackSpeed));
         Vec3f cameraTarget = offsetTargetPosition(target.getPosition());
 
         // Percentage of screen near edges where the scale is increased when
         // target is within this threshold percentage of the screen's edge
-        float SCREEN_THRESH_PERC = 0.01f;
+        float SCREEN_THRESH_PERC = 0.05f;
 
         // Factor to increase scale by
         float SCALE_FACTOR = 2.0f;
@@ -68,7 +65,7 @@ public class TargetTrackerCamera {
                 || screenPos.x > screen.w * (1 - SCREEN_THRESH_PERC)
                 || screenPos.y < screen.h * SCREEN_THRESH_PERC
                 || screenPos.y > screen.h * (1 - SCREEN_THRESH_PERC)) {
-            // Outude of SCREEN_THRESH_PERC boundaries so increase scale by
+            // Outside of SCREEN_THRESH_PERC boundaries so increase scale by
             // SCALE_FACTOR
             scale = (float) (1 - (0.02f * playbackSpeed * SCALE_FACTOR));
         }


### PR DESCRIPTION
…when the ball is near the edges of the screen.  This serves to try and keep the camera in view of the ball even if the ball is traveling fast after having been kicked.  This change is tuneable with the area in which the scale is increased set by SCREEN_THRESH_PERC, and the amount the scale is increased controlled by SCALE_FACTOR.

This change has been tested with the 2016 utaustinvilla released agent kicking the ball from the center circle during PlayOn toward the opponent's goal.  More often than not the agent's kick is strong enough to score a goal, and also fast enough to move outside the camera's view which this change now prevents.

Closes #90.