### PR TITLE
Small enhancements for macOS

### DIFF
--- a/scripts/roboviz.sh
+++ b/scripts/roboviz.sh
@@ -20,4 +20,9 @@ set -- $args
 DIR="$( cd "$( dirname "$0" )" && pwd )" 
 cd $DIR
 
-java -Xmx512m -jar RoboViz.jar "$@"
+if [[ `uname -s` == "Darwin" ]];
+then
+	java -Xmx512m -Xdock:name="RoboViz" -jar RoboViz.jar "$@"
+else
+	java -Xmx512m -jar RoboViz.jar "$@"
+fi

--- a/viewer/src/main/java/rv/Viewer.java
+++ b/viewer/src/main/java/rv/Viewer.java
@@ -61,6 +61,7 @@ import rv.comm.rcssserver.scenegraph.SceneGraph;
 import rv.content.ContentManager;
 import rv.ui.UserInterface;
 import rv.ui.menus.MenuBar;
+import rv.util.MacEnhancements;
 import rv.util.commandline.Argument;
 import rv.util.commandline.BooleanArgument;
 import rv.util.commandline.IntegerArgument;
@@ -260,6 +261,10 @@ public class Viewer
 
 	private void initComponents(GLCapabilities caps)
 	{
+		if (MacEnhancements.IS_MAC) {
+			MacEnhancements.useSystemMenuBar();
+		}
+
 		Globals.setLookFeel(config.general.lookAndFeel);
 		canvas = new GLCanvas(caps);
 		canvas.setFocusTraversalKeysEnabled(false);

--- a/viewer/src/main/java/rv/util/MacEnhancements.java
+++ b/viewer/src/main/java/rv/util/MacEnhancements.java
@@ -2,7 +2,7 @@ package rv.util;
 
 public class MacEnhancements
 {
-	public static boolean IS_MAC = System.getProperty("os.name").contains("OS X");
+	public static final boolean IS_MAC = System.getProperty("os.name").contains("OS X");
 
 	public static void useSystemMenuBar()
 	{

--- a/viewer/src/main/java/rv/util/MacEnhancements.java
+++ b/viewer/src/main/java/rv/util/MacEnhancements.java
@@ -1,0 +1,11 @@
+package rv.util;
+
+public class MacEnhancements
+{
+	public static boolean IS_MAC = System.getProperty("os.name").contains("OS X");
+
+	public static void useSystemMenuBar()
+	{
+		System.setProperty("apple.laf.useScreenMenuBar", "true");
+	}
+}


### PR DESCRIPTION
This moves the application's menu bar to the system menu bar of macOS. As a side effect, the menu bar is still accessible when the look and feel is set to Nimbus.

For other stuff like using the proper application icon, we would need to bundle RoboViz into a macOS application bundle (.app). But I think that would probably not be worth the effort at the moment. (And it would also require to not start RoboViz from the command line.)