### PR TITLE
Add an optional buffering mechanism for bad network connections

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -31,6 +31,8 @@ Auto-Connect         : true
 Auto-Connect Delay   : 1000
 Default Server       : localhost:3200
 Drawing Port         : 32769
+Monitor Step         : 0.04
+Network Buffer       : false
 # To store more servers, just insert more "Server" lines
 Server               : localhost:3200
 

--- a/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/Config.kt
+++ b/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/Config.kt
@@ -126,49 +126,49 @@ class Config(args: Array<String>) {
      */
     fun read() {
         // General
-        General.recordLogs = parser.getValue("Record Logfiles").toBoolean()
-        General.logfileDirectory = parser.getValue("Logfile Directory")
-        General.lookAndFeel = parser.getValue("Look and Feel")
+        parser.getValue("Record Logfiles")?.let { General.recordLogs = it.toBoolean() }
+        parser.getValue("Logfile Directory")?.let { General.logfileDirectory = it }
+        parser.getValue("Look and Feel")?.let { General.lookAndFeel = it }
 
         // Graphics
-        Graphics.useBloom = parser.getValue("Bloom").toBoolean()
-        Graphics.usePhong = parser.getValue("Phong").toBoolean()
-        Graphics.useShadows = parser.getValue("Shadows").toBoolean()
-        Graphics.useSoftShadows = parser.getValue("Soft Shadows").toBoolean()
-        Graphics.shadowResolution = parser.getValue("Shadow Resolution").toInt()
-        Graphics.useStereo = parser.getValue("Stereo 3D").toBoolean()
-        Graphics.useVsync = parser.getValue("V-Sync").toBoolean()
-        Graphics.useFsaa = parser.getValue("FSAA").toBoolean()
-        Graphics.fsaaSamples = parser.getValue("FSAA Samples").toInt()
-        Graphics.targetFPS = parser.getValue("Target FPS").toInt()
-        Graphics.firstPersonFOV = parser.getValue("First Person FOV").toInt()
-        Graphics.thirdPersonFOV = parser.getValue("Third Person FOV").toInt()
+        parser.getValue("Bloom")?.let { Graphics.useBloom = it.toBoolean() }
+        parser.getValue("Phong")?.let { Graphics.usePhong = it.toBoolean() }
+        parser.getValue("Shadows")?.let { Graphics.useShadows = it.toBoolean() }
+        parser.getValue("Soft Shadows")?.let { Graphics.useSoftShadows = it.toBoolean() }
+        parser.getValue("Shadow Resolution")?.let { Graphics.shadowResolution = it.toInt() }
+        parser.getValue("Stereo 3D")?.let { Graphics.useStereo = it.toBoolean() }
+        parser.getValue("V-Sync")?.let { Graphics.useVsync = it.toBoolean() }
+        parser.getValue("FSAA")?.let { Graphics.useFsaa = it.toBoolean() }
+        parser.getValue("FSAA Samples")?.let { Graphics.fsaaSamples = it.toInt() }
+        parser.getValue("Target FPS")?.let { Graphics.targetFPS = it.toInt() }
+        parser.getValue("First Person FOV")?.let { Graphics.firstPersonFOV = it.toInt() }
+        parser.getValue("Third Person FOV")?.let { Graphics.thirdPersonFOV = it.toInt() }
 
-        Graphics.frameWidth = parser.getValue("Frame Width").toInt()
-        Graphics.frameHeight = parser.getValue("Frame Height").toInt()
-        Graphics.frameX = parser.getValue("Frame X").toInt()
-        Graphics.frameY = parser.getValue("Frame Y").toInt()
-        Graphics.centerFrame = parser.getValue("Center Frame").toBoolean()
-        Graphics.isMaximized = parser.getValue("Frame Maximized").toBoolean()
-        Graphics.saveFrameState = parser.getValue("Save Frame State").toBoolean()
+        parser.getValue("Frame Width")?.let { Graphics.frameWidth = it.toInt() }
+        parser.getValue("Frame Height")?.let { Graphics.frameHeight = it.toInt() }
+        parser.getValue("Frame X")?.let { Graphics.frameX = it.toInt() }
+        parser.getValue("Frame Y")?.let { Graphics.frameY = it.toInt() }
+        parser.getValue("Center Frame")?.let { Graphics.centerFrame = it.toBoolean() }
+        parser.getValue("Frame Maximized")?.let { Graphics.isMaximized = it.toBoolean() }
+        parser.getValue("Save Frame State")?.let { Graphics.saveFrameState = it.toBoolean() }
 
         // Networking
-        Networking.autoConnect = parser.getValue("Auto-Connect").toBoolean()
-        Networking.autoConnectDelay = parser.getValue("Auto-Connect Delay").toInt()
-        Networking.listenPort = parser.getValue("Drawing Port").toInt()
+        parser.getValue("Auto-Connect")?.let { Networking.autoConnect = it.toBoolean() }
+        parser.getValue("Auto-Connect Delay")?.let { Networking.autoConnectDelay = it.toInt() }
+        parser.getValue("Drawing Port")?.let { Networking.listenPort = it.toInt() }
 
         parser.getValuePairList("Server").forEach {
             Networking.servers.add(Pair(it.first, it.second.toInt()))
         }
-        Networking.defaultServerHost = parser.getValue("Default Server").substringBefore(":")
-        Networking.defaultServerPort = parser.getValue("Default Server").substringAfter(":").toInt()
+        parser.getValue("Default Server")?.let { Networking.defaultServerHost = it.substringBefore(":") }
+        parser.getValue("Default Server")?.let { Networking.defaultServerPort = it.substringAfter(":").toInt() }
 
         // OverlayVisibility
-        OverlayVisibility.serverSpeed = parser.getValue("Server Speed").toBoolean()
-        OverlayVisibility.foulOverlay = parser.getValue("Foul Overlay").toBoolean()
-        OverlayVisibility.fieldOverlay = parser.getValue("Field Overlay").toBoolean()
-        OverlayVisibility.numberOfPlayers = parser.getValue("Number of Players").toBoolean()
-        OverlayVisibility.playerIDs = parser.getValue("Player IDs").toBoolean()
+        parser.getValue("Server Speed")?.let { OverlayVisibility.serverSpeed = it.toBoolean() }
+        parser.getValue("Foul Overlay")?.let { OverlayVisibility.foulOverlay = it.toBoolean() }
+        parser.getValue("Field Overlay")?.let { OverlayVisibility.fieldOverlay = it.toBoolean() }
+        parser.getValue("Number of Players")?.let { OverlayVisibility.numberOfPlayers = it.toBoolean() }
+        parser.getValue("Player IDs")?.let { OverlayVisibility.playerIDs = it.toBoolean() }
 
         // TeamColors
         parser.getValuePairList("Team Color").forEach {

--- a/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/Config.kt
+++ b/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/Config.kt
@@ -77,6 +77,9 @@ class Config(args: Array<String>) {
 
         var currentHost = defaultServerHost
         var currentPort = defaultServerPort
+
+        var monitorStep = 0.04
+        var useBuffer = false
     }
 
     object OverlayVisibility {
@@ -156,6 +159,8 @@ class Config(args: Array<String>) {
         parser.getValue("Auto-Connect")?.let { Networking.autoConnect = it.toBoolean() }
         parser.getValue("Auto-Connect Delay")?.let { Networking.autoConnectDelay = it.toInt() }
         parser.getValue("Drawing Port")?.let { Networking.listenPort = it.toInt() }
+        parser.getValue("Monitor Step")?.let { Networking.monitorStep = it.toDouble() }
+        parser.getValue("Network Buffer")?.let { Networking.useBuffer = it.toBoolean() }
 
         parser.getValuePairList("Server").forEach {
             Networking.servers.add(Pair(it.first, it.second.toInt()))
@@ -230,6 +235,9 @@ class Config(args: Array<String>) {
 
         parser.setValuePairList("Server", Networking.servers.map { Pair(it.first, it.second.toString()) })
         parser.setValue("Default Server", "${Networking.defaultServerHost}:${Networking.defaultServerPort}")
+
+        parser.setValue("Monitor Step", Networking.monitorStep.toString())
+        parser.setValue("Network Buffer", Networking.useBuffer.toString())
 
         // OverlayVisibility
         parser.setValue("Server Speed", OverlayVisibility.serverSpeed.toString())

--- a/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/ConfigParser.kt
+++ b/src/main/kotlin/org/magmaoffenburg/roboviz/configuration/ConfigParser.kt
@@ -72,7 +72,14 @@ class ConfigParser {
 
         fileMap.forEach { pair ->
             val index = rawFileList.indexOfFirst { matchKey(it, pair.key) }
-            rawFileList[index] = "${pair.key.padEnd(20)} : ${pair.value}"
+            val updatedLine = "${pair.key.padEnd(20)} : ${pair.value}"
+            if (index == -1) {
+                // Key not yet present in config file
+                // Add it to the bottom of the file
+                rawFileList.add(updatedLine)
+            } else {
+                rawFileList[index] = updatedLine
+            }
         }
         filePairMap.forEach { pairList ->
             val firstIndex = rawFileList.indexOfFirst { matchKey(it, pairList.key) }
@@ -94,8 +101,8 @@ class ConfigParser {
     /**
      * get the value of a key
      */
-    fun getValue(key: String) = fileMap[key] ?: "".also {
-        logger.error("The key \"$key\" does not exist!")
+    fun getValue(key: String) = fileMap[key] ?: null.also {
+        logger.warn("The key \"$key\" does not exist!")
     }
 
 
@@ -103,7 +110,7 @@ class ConfigParser {
      * get the value pair list of a key
      */
     fun getValuePairList(key: String) = filePairMap[key] ?: emptyList<Pair<String, String>>().also {
-        logger.error("The key \"$key\" does not exist!")
+        logger.warn("The key \"$key\" does not exist!")
     }
 
     /**

--- a/src/main/kotlin/org/magmaoffenburg/roboviz/gui/windows/config/ServerPanel.kt
+++ b/src/main/kotlin/org/magmaoffenburg/roboviz/gui/windows/config/ServerPanel.kt
@@ -22,6 +22,9 @@ class ServerPanel: JPanel() {
     private val defaultServerPortSpinner = JSpinner(SpinnerNumberModel(Networking.defaultServerPort, 0, Int.MAX_VALUE, 1))
     private val drawingPortLabel = JLabel("Drawing Port:")
     private val drawingPortSpinner = JSpinner(SpinnerNumberModel(Networking.listenPort, 0, Int.MAX_VALUE, 1))
+    private val monitorStepLabel = JLabel("Monitor step duration:")
+    private val monitorStepSpinner = JSpinner(SpinnerNumberModel(Networking.monitorStep, 0.0, Double.MAX_VALUE, 0.01))
+    private val useBufferCB = JCheckBox("Use Buffer", Networking.useBuffer)
     private val serverListButton = JButton("Open Server List")
 
     init {
@@ -62,6 +65,11 @@ class ServerPanel: JPanel() {
                         .addComponent(drawingPortLabel, 0, 125, 125)
                         .addComponent(drawingPortSpinner, 0, 120, 120)
                 )
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(monitorStepLabel, 0, 125, 125)
+                    .addComponent(monitorStepSpinner, 0, 120, 120)
+                )
+                .addComponent(useBufferCB, 0, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE.toInt())
                 .addComponent(serverListButton, 0, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE.toInt())
         )
 
@@ -87,6 +95,11 @@ class ServerPanel: JPanel() {
                         .addComponent(drawingPortLabel)
                         .addComponent(drawingPortSpinner)
                 )
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(monitorStepLabel)
+                    .addComponent(monitorStepSpinner)
+                )
+                .addComponent(useBufferCB)
                 .addComponent(serverListButton)
         )
     }
@@ -123,6 +136,12 @@ class ServerPanel: JPanel() {
         }
         serverListButton.addActionListener {
             ServerListDialog.showDialog()
+        }
+        monitorStepSpinner.addChangeListener {
+            Networking.monitorStep = monitorStepSpinner.value as Double
+        }
+        useBufferCB.addActionListener {
+            Networking.useBuffer = useBufferCB.isSelected
         }
     }
 


### PR DESCRIPTION
This implements the ["buffering proxy"](https://github.com/hannesbraun/spark-buffer) we used in Bangkok last year directly into RoboViz. It should be a lot more reliable than the external proxy. What it does is fairly simple: if data for multiple cycles arrives at the same time, RoboViz is going to wait for the duration of a monitor cycle between applying/rendering these frames.

This buffering mechanism is disabled by default. Usually, a good network connection is available and this isn't required. This also avoids being out of sync with the live state of the simulation.

The duration of a monitor cycle needs to be defined manually with the "Monitor Step" setting. I'm not aware of an option to get this property through the monitor protocol.

To not break the config files again, I also improved the config reading mechanism a bit. If a value is not present yet in the config file, RoboViz will fallback to its default value and store it at the end of the config file (when writing back changes).